### PR TITLE
ffmpeg7.0.1にかかわる問題

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 任意のサイズに収まるようにビットレートを自動で調整することができます。
 # セットアップ
 ```setup.bat```を実行してください。  
-なお、ffmpeg7.0.1で正常に実行できない不具合を確認しています。  
-暫定的に、setupスクリプトでインストールされるffmpegのバージョンを6.1.1に指定して対処しています。
-## 手動で実行する場合は
+
+## 手動でセットアップを実行する場合は
 ```
-winget install ffmpeg -v 6.1.1
+winget install ffmpeg
 pip install ffmpeg-python
 ```
 を実行したのち、設定ファイルsettings.pyを作成してください。  
@@ -34,3 +33,14 @@ OUTPUT_FILENAME = "output.mp4" #出力ファイル名
 動画は基本的に3Mbpsでエンコードされます。  
 予想ファイルサイズが設定値を超える場合は、映像ビットレートを自動で下げて調整します。  
 音声のビットレートは320kbps固定です。
+
+# トラブルシューティング
+## ffmpegが見つからない
+ffmpegのインストール時に、wingetによるpathの設定に失敗する場合があります。
+ffmpegをインストールしたのち、コマンドプロンプトを再起動して以下のコマンドを実行し、ffmpepgが正常に実行できるか確認してください。
+```
+ffmpeg -version
+```
+正常に実行できない場合は、環境変数Pathが正常に設定されていない可能性があります。  
+本プログラムは実行時に一時的な環境変数を設定しているため、Pathが通っていなくても実行できる場合がありますが、どうしても実行できない場合は、以下を環境変数Pathに追加してください。  
+```C:\Users\\{ユーザ名}\AppData\Local\Microsoft\WinGet\Packages\Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe\ffmpeg-7.0.1-full_build```

--- a/setup.bat
+++ b/setup.bat
@@ -1,7 +1,7 @@
 @echo off
 
 echo Installing ffmpeg...
-winget install ffmpeg -v 6.1.1
+winget install ffmpeg
 
 echo Installing Libraries...
 pip install ffmpeg-python

--- a/ここに動画をD&D.bat
+++ b/ここに動画をD&D.bat
@@ -1,13 +1,41 @@
 @echo off
+setlocal enabledelayedexpansion
 
 cd /d "%~dp0"
 
-if "%~1"=="" (
-    echo File not specified.
+set PACKAGE_DIR=%USERPROFILE%\AppData\Local\Microsoft\WinGet\Packages\Gyan.FFmpeg_Microsoft.Winget.Source_*
+set BIN_DIR=ffmpeg-*-full_build
+set MATCH=
+
+if not exist "!PACKAGE_DIR!" (
+    echo 検索ディレクトリが存在しません。
     pause
-    exit /b 1
-) else (
-    python VideoTimeCoder.py "%~1"
+    rem exit /b 1
 )
 
+for /d %%G in ("!PACKAGE_DIR!") do (
+    if not defined MATCH (
+        set MATCH=%%G
+    )
+)
+
+for /d %%G in (!MATCH!\!BIN_DIR!) do (
+    set MATCH=%%G\bin
+)
+
+if defined MATCH (
+    echo Add the following to PATH : !MATCH!
+    set PATH=!PATH!;!MATCH!
+    if "%~1"=="" (
+        echo File not specified.
+        pause
+        exit /b 1
+    ) else (
+        python VideoTimeCoder.py "%~1"
+    )
+) else (
+    echo Not matched
+)
+
+endlocal
 if %ERRORLEVEL% neq 0 pause


### PR DESCRIPTION
ffmpegをアップデート後に本プログラムの起動に失敗するのは、ffmpegへpathが通っていなかったことが原因だった。
その旨readmeに追記したうえで、起動時にffmpegの場所を探索し、起動バッチによって一時的に環境変数を設定するようにした。
プログラム本体への修正は無し。
#1 